### PR TITLE
fix(options): stop preview text being requested on page load

### DIFF
--- a/src/js/bionic-reading-api.js
+++ b/src/js/bionic-reading-api.js
@@ -68,6 +68,8 @@ const readLocalStorage = async (key) => {
 };
 
 /**
- * On page load, request for Bionic Reading.
+ * On page load, request for Bionic Reading of content stored.
  */
-autoRequestBionic();
+if (document.title != 'Bionic Reading Chrome Extension'){
+  autoRequestBionic();
+}


### PR DESCRIPTION
conditional if statement to check the page title, was previously loading the local storage contents value onto the options page, without the users request.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
