### PR TITLE
Feature/use url for convert

### DIFF
--- a/src/js/convert.js
+++ b/src/js/convert.js
@@ -10,6 +10,7 @@ async function convertPage() {
   let saccade = await readLocalStorage("saccade");
 
   let arrayText = document.getElementsByTagName("p");
+  console.log(document.URL);
   let response = await requestBionic(
     apiKey,
     document.URL,

--- a/src/js/convert.js
+++ b/src/js/convert.js
@@ -19,7 +19,8 @@ async function convertPage() {
     true
   );
   console.log(response);
-  let responseText = DOMParser()
+  const parser = new DOMParser();
+  let responseText = parser
     .parseFromString(response, "text/html")
     .getElementsByTagName("p");
   console.log(responseText);

--- a/src/js/convert.js
+++ b/src/js/convert.js
@@ -10,7 +10,6 @@ async function convertPage() {
   let saccade = await readLocalStorage("saccade");
 
   let arrayText = document.getElementsByTagName("p");
-  console.log(document.URL);
   let response = await requestBionic(
     apiKey,
     document.URL,
@@ -18,7 +17,6 @@ async function convertPage() {
     saccade,
     true
   );
-  console.log(response);
   const parser = new DOMParser();
   let responseText = parser
     .parseFromString(response, "text/html")

--- a/src/js/convert.js
+++ b/src/js/convert.js
@@ -18,6 +18,7 @@ async function convertPage() {
     saccade,
     true
   );
+  console.log(response);
   let responseText = DOMParser()
     .parseFromString(response, "text/html")
     .getElementsByTagName("p");

--- a/src/js/convert.js
+++ b/src/js/convert.js
@@ -10,7 +10,13 @@ async function convertPage() {
   let saccade = await readLocalStorage("saccade");
 
   let arrayText = document.getElementsByTagName("p");
-  let response = requestBionic(apiKey, document.URL, fixation, saccade, true);
+  let response = await requestBionic(
+    apiKey,
+    document.URL,
+    fixation,
+    saccade,
+    true
+  );
   let responseText = DOMParser()
     .parseFromString(response, "text/html")
     .getElementsByTagName("p");

--- a/src/js/convert.js
+++ b/src/js/convert.js
@@ -5,15 +5,17 @@
  *
  */
 async function convertPage() {
-  let apiKey = await readLocalStorage('apiKey');
-  let fixation = await readLocalStorage('fixation');
-  let saccade = await readLocalStorage('saccade');
+  let apiKey = await readLocalStorage("apiKey");
+  let fixation = await readLocalStorage("fixation");
+  let saccade = await readLocalStorage("saccade");
 
   let arrayText = document.getElementsByTagName("p");
+  let response = requestBionic(apiKey, document.URL, fixation, saccade, true);
+  let responseText = DOMParser()
+    .parseFromString(response, "text/html")
+    .getElementsByTagName("p");
   for (let i = 0; i < arrayText.length; i++) {
-    let innerText = arrayText[i].innerText;
-    let text = await requestBionic(apiKey, innerText, fixation, saccade, true)
-    arrayText[i].innerHTML = text;
+    arrayText[i].innerHTML = responseText[i].innerHTML;
   }
 }
 

--- a/src/js/convert.js
+++ b/src/js/convert.js
@@ -14,6 +14,7 @@ async function convertPage() {
   let responseText = DOMParser()
     .parseFromString(response, "text/html")
     .getElementsByTagName("p");
+  console.log(responseText);
   for (let i = 0; i < arrayText.length; i++) {
     arrayText[i].innerHTML = responseText[i].innerHTML;
   }


### PR DESCRIPTION
# Description

This uses the URL of the page for the bionic reading API request rather than doing a separate request for each text block for convertPage. The goal / motivation is to limit the number of API calls required assuming people will want to use the Basic plan. Motivation generally is that I really want to use this extension lol

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
