### PR TITLE
feat(convert): allow the user to toggle between using page url or paragraphs for pages

### DIFF
--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,27 +1,25 @@
-div{
+div {
   color: black;
-  margin:auto;
+  margin: auto;
   width: fit-content;
   height: fit-content;
-  text-align: center;
+  text-align: left;
   font-size: 1.1em;
 }
 
-body{
+body {
   background-color: white;
   margin: auto;
-  width: 50%;
   border: 0px solid black;
   padding: 30px;
   font-family: monospace;
-
 }
 
-p{
+p {
   font-size: 14px;
   margin: auto;
   margin-top: 10px;
-  max-width: 400px;
+  max-width: 450px;
 }
 
 button {
@@ -35,6 +33,21 @@ button {
   font-size: 20px;
 }
 
-input{
-  width: 390px;
+#apiKey {
+  width: 450px;
+  height: 30px;
+  font-family: monospace;
+}
+
+#optionButtons {
+  padding: 10px 0 0 0;
+}
+
+[type="checkbox"] {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.newFeature b {
+  color: red;
 }

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -1,69 +1,93 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <link rel= "stylesheet" href="../css/options.css">
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/x-icon" href="../images/brc_logo128.png" />
-    <title>Bionic Speed Reader</title>
-  </head>
 
-  <body>
-    <div id="options">
-      <div id="apiKeyOption">
-        <h2>Enter your RapidAPI Key</h2>
-        <label>
-          <input type="text" name="rapid-api" id="apiKey" />
-        </label>
-      </div>
+<head>
+  <link rel="stylesheet" href="../css/options.css">
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/x-icon" href="../images/brc_logo128.png" />
+  <title>Bionic Speed Reader</title>
+</head>
 
-      <div id="fixationOption">
-        <h2>Fixation</h2>
-        <label>
-          <button id="btn1" value="1">1</button>
-          <button id="btn2" value="2">2</button>
-          <button id="btn3" value="3">3</button>
-          <button id="btn4" value="4">4</button>
-          <button id="btn5" value="5">5</button>
-        </label>
+<body>
+  <div id="options">
+    <div id="apiKeyOption">
+      <h2>Enter your RapidAPI Key</h2>
+      <label>
+        <input type="text" name="rapid-api" id="apiKey" />
+      </label>
+    </div>
+
+    <div id="fixationOption">
+      <h2>Fixation</h2>
+      <label>
+        <button id="btn1" value="1">1</button>
+        <button id="btn2" value="2">2</button>
+        <button id="btn3" value="3">3</button>
+        <button id="btn4" value="4">4</button>
+        <button id="btn5" value="5">5</button>
+      </label>
+      <p>
+        With the Fixation you define how much of a word is bold when it is bolded. 1 is half of the word bold and 5 is
+        least amount bold.
+      </p>
+    </div>
+
+    <div id="saccadeOption">
+      <h2>Saccade</h2>
+      <label>
+        <button id="btn10" value="10">10</button>
+        <button id="btn20" value="20">20</button>
+        <button id="btn30" value="30">30</button>
+        <button id="btn40" value="40">40</button>
+        <button id="btn50" value="50">50</button>
+      </label>
+      <p>
+        With the Saccade you define how common it is for a word to be bolded 10 is every word and 50 is least.
+      </p>
+    </div>
+
+    <div id="previewOption">
+      <h2>Preview</h2>
+      <p id="previewText">The quick brown fox jumps over the lazy dog</p>
+      <div id="bionic-response"></div>
+      <p>
+        <b>Note:</b> Save your changes before pressing the 'Preview' button.
+      </p>
+    </div>
+
+    <div id="experimentalModes">
+      <h2>Experimental Features</h2>
+      <div id="toggleWebsiteConvert">
+        <p class="newFeature"><b>**New**</b> Convert webpage using page url <b>**New**</b></p>
         <p>
-          With the Fixation you define how much of a word is bold when it is bolded. 1 is half of the word bold and 5 is least amount bold
+          <u>Recommended:</u> Enabling this option will use the current webpage url, as the content to be used for
+          requesting
+          text in Bionic Reading format. Please note, converting a webpage may take longer than usual to convert and
+          webpages may not keep their original formatting.
         </p>
-      </div>
-
-      <div id="saccadeOption">
-        <h2>Saccade</h2>
-        <label>
-          <button id="btn10" value="10">10</button>
-          <button id="btn20" value="20">20</button>
-          <button id="btn30" value="30">30</button>
-          <button id="btn40" value="40">40</button>
-          <button id="btn50" value="50">50</button>
-        </label>
         <p>
-          With the Saccade you define how common it is for a word to be bolded 10 is every word and 50 is least.
+          Disabling this feature, may result in reaching your daily API limit quicker, as multiple API calls will be
+          made to convert a webpage.
+          <label>Enable</label>
+          <input id="enableFeature1E" type="checkbox" value="enable" />
+          <label>Disable</label>
+          <input id="enableFeature1D" type="checkbox" value="disable" />
         </p>
-      </div>
-
-      <div id="previewOption">
-        <h2>Preview</h2>
-        <p id="previewText">The quick brown fox jumps over the lazy dog</p>
-        <div id="bionic-response"></div>
-        <p>
-          <b>Note:</b> Save your changes before pressing the 'Preview' button.
-        </p>
-      </div>
-
-      <div>
-        <button id="submit">Save</button>
-        <button id="preview">Preview</button>
-        <button id="clear">Clear local storage</button>
       </div>
     </div>
-    <!-- Loaded last, or will not be able get the elements on page -->
-    <script src="../js/bionic-reading-api.js"></script>
-    <script src="../js/utility.js"></script>
-    <script src="../js/options.js"></script>
-  </body>
+
+    <div id="optionButtons">
+      <button id="submit">Save</button>
+      <button id="preview">Preview</button>
+      <button id="clear">Clear local storage</button>
+    </div>
+  </div>
+  <!-- Loaded last, or will not be able get the elements on page -->
+  <script src="../js/bionic-reading-api.js"></script>
+  <script src="../js/utility.js"></script>
+  <script src="../js/options.js"></script>
+</body>
+
 </html>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,10 +1,12 @@
 /**
  * Set fixation and saccade values locally in the users storage after extension,
- * has been installed.
+ * has been installed. Additionally, enable any experimental features, which may
+ * be beneficial to the user.
  */
 chrome.runtime.onInstalled.addListener(() => {
   chrome.storage.local.set({ fixation: "1" });
   chrome.storage.local.set({ saccade: "10" });
+  chrome.storage.local.set({ convertWithUrl: "enable" });
 });
 
 /**

--- a/src/js/convert.js
+++ b/src/js/convert.js
@@ -4,11 +4,10 @@
  * get all of the p tags on the page originally and
  * replace the innerHTML with the innerHTML of the corresponding response p tag
  */
-async function convertPage() {
-  let apiKey = await readLocalStorage('apiKey');
-  let fixation = await readLocalStorage('fixation');
-  let saccade = await readLocalStorage('saccade');
-
+async function convertPageWithWebpageUrl() {
+  let apiKey = await readLocalStorage("apiKey");
+  let fixation = await readLocalStorage("fixation");
+  let saccade = await readLocalStorage("saccade");
   const parser = new DOMParser();
   const response = await requestBionic(
     apiKey,
@@ -27,4 +26,34 @@ async function convertPage() {
   }
 }
 
-convertPage();
+/**
+ * Find all elements with the p tag and for each one,
+ * get the inner text for that tag, to be used as the content
+ * for the post request to get the text in Bionic Reading format.
+ *
+ * Note: requesting for each paragraph to be converted means more
+ * API calls are made to RapidAPI and may result in the user reaching,
+ * their daily API limit quicker.
+ */
+async function convertPageWithParagraphs() {
+  let arrayText = document.getElementsByTagName("p");
+  let apiKey = await readLocalStorage("apiKey");
+  let fixation = await readLocalStorage("fixation");
+  let saccade = await readLocalStorage("saccade");
+  for (let i = 0; i < arrayText.length; i++) {
+    let innerText = arrayText[i].innerText;
+    let text = await requestBionic(apiKey, innerText, fixation, saccade, true);
+    arrayText[i].innerHTML = text;
+  }
+}
+
+async function checkFeaturesEnabled() {
+  let convertWithUrl = await readLocalStorage("convertWithUrl");
+  if (convertWithUrl == "enable") {
+    convertPageWithWebpageUrl();
+  } else if (convertWithUrl == "disable") {
+    convertPageWithParagraphs();
+  }
+}
+
+checkFeaturesEnabled();

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,36 +1,79 @@
-
+/**
+ * Experimental Feature check boxes
+ */
+let disabledF1Check = document.getElementById("enableFeature1D");
+let enableF1Check = document.getElementById("enableFeature1E");
 
 /**
  * Listen for click event, to initiate saving of the users options.
  */
-const btnSubmit = document.getElementById('submit');
-btnSubmit.addEventListener('click', saveDataOptions);
+const btnSubmit = document.getElementById("submit");
+btnSubmit.addEventListener("click", saveDataOptions);
 
 /**
  * Listen for click event, to initiate POST request to update preview.
  */
-const btnPreview = document.getElementById('preview');
-btnPreview.addEventListener('click', previewChanges);
+const btnPreview = document.getElementById("preview");
+btnPreview.addEventListener("click", previewChanges);
 
 /**
- * Listen for click event, to clear local extension storage
+ * Toggle feature for using webpage url as the content for,
+ * convert.
  */
+const checkBoxF1 = document.getElementById("toggleWebsiteConvert");
+checkBoxF1.addEventListener("click", (Event) => {
+  const toggleF1 = Event.target.value;
+  toggleFeature1(toggleF1);
+});
+
 /**
- * Clear extension local storage
+ * Clear all extension local storage.
  */
-const btnClear = document.getElementById('clear');
-btnClear.addEventListener('click', () => chrome.storage.local.clear());
+const btnClear = document.getElementById("clear");
+btnClear.addEventListener("click", () => chrome.storage.local.clear());
 
 /**
  * Make a post request using the preview text as content,
  * response is shown on the page.
  */
 function previewChanges() {
-  const content = document.getElementById('previewText').innerHTML;
+  const content = document.getElementById("previewText").innerHTML;
   requestBionic(apiKey, content, fixation, saccade);
 }
 
 /**
- * Initialize the page displaying users current options set
+ * Set local storage if experimental feature is enabled or
+ * disabled and change the checkbox from true/false.
+ * @param {String} value
+ */
+function toggleFeature1(value) {
+  chrome.storage.local.set({ convertWithUrl: value });
+  if (value == "disable") {
+    enableF1Check.checked = false;
+  } else if (value == "enable") {
+    disabledF1Check.checked = false;
+  }
+}
+
+/**
+ * Check which features user has enabled/disabled
+ * and check the corresponding checkbox.
+ */
+async function displayExperimentalFeaturesEnabled() {
+  let convertWithUrl = await readLocalStorage("convertWithUrl");
+  if (convertWithUrl == "enable") {
+    enableF1Check.checked = true;
+  } else {
+    disabledF1Check.checked = true;
+  }
+}
+
+/**
+ * Initialize the page displaying users current options set.
  */
 displayCurrentOptions();
+
+/**
+ * Check which experimental features the user has enabled.
+ */
+displayExperimentalFeaturesEnabled();


### PR DESCRIPTION
# Description

new section has been added to the options page, 'experimental features' to allow users to toggle different features. this has been added as converting a page using an url causes the page to lose its formatting and not all content is converted to bionic reading. users have the option to opt-out of using the webpage url to convert and use the websites paragraphs, which does not affect the page format, but makes more api calls.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
