### PR TITLE
refactor(permissions): remove `tabs` from list of extension permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "background": {
     "service_worker": "./src/js/background.js"
   },
-  "permissions": ["activeTab", "contextMenus", "scripting", "storage", "tabs"],
+  "permissions": ["activeTab", "contextMenus", "scripting", "storage"],
   "action": {
     "default_popup": "./src/html/popup.html"
   },


### PR DESCRIPTION
# Description

reduce amount of permissions needed by the extension, as `tabs` does not need to be declared to access some of the chrome APIs e.g. `chrome.tabs` as per https://developer.chrome.com/docs/extensions/mv3/permission_warnings/#permissions_with_warnings

## Type of change

Please delete options that are not relevant.

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
