### PR TITLE
docs: remove the name 'bionic reading' from the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<h1><b>Bion</b>ic <b>Readi</b>ng <b>Chro</b>me <b>Extensi</b>on</h1>
+# Bionic Speed Reader Browser Extension
 
-A simple chrome extension using [Bionic Reading API](https://rapidapi.com/bionic-reading-bionic-reading-default/api/bionic-reading1/), provided by [RapidAPI](https://rapidapi.com/hub).
+A simple browser extension using [Bionic Reading API](https://rapidapi.com/bionic-reading-bionic-reading-default/api/bionic-reading1/), provided by [RapidAPI](https://rapidapi.com/hub).
 
 <p style="text-align:center"> 🚧  👷 Currently in the early stages of development 👷 🚧 </p>
 
@@ -21,13 +21,13 @@ A simple chrome extension using [Bionic Reading API](https://rapidapi.com/bionic
 
 ## Usage
 
-1. On your browsers extension page, click 'Details' on Bionic Reading Chrome Extension.
+1. On your browsers extension page, click 'Details' on Bionic Speed Reader Browser Extension.
 2. Next click 'Extension options'.
 3. Enter your RapidAPI Key that is subscribed to the Bionic Reading API.
 4. You can change your fixation (default: 1) and saccade (default: 10).
 5. If you want to preview your changes, click 'Save' first, then 'Preview' button.
-6. Highlight text on a page and right click and select 'Bionic Reading convert text ...'
-7. Alternately, not selecting any text, right click the page and select 'Bionic Reading convert page'
+6. Highlight text on a page and right click and select 'Bionic Speed Reading convert text ...'
+7. Alternately, not selecting any text, right click the page and select 'Bionic Speed Reading convert page'
 
 ## FAQ
 
@@ -54,6 +54,7 @@ Documentation of using RapidAPI can be found [here](https://docs.rapidapi.com/do
 
 ## Disclaimer
 
-Un-official chrome extension for Bionic Reading (BR®). All trademarks are the property of their respective owners.
+This project is not afflicted with Bionic Reading (BR®). All trademarks are the property of their respective owners.
 
-For more information on Bionic Reading and how it works, please see: https://bionic-reading.com/about/
+For more information on Bionic Reading and how it works, please see: https://bionic-reading.com/about/. Additionally, you can
+find the official Chrome extension [here](https://chrome.google.com/webstore/detail/bionic-reading/kdfkejelgkdjgfoolngegkhkiecmlflj).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Documentation of using RapidAPI can be found [here](https://docs.rapidapi.com/do
 
 ## Disclaimer
 
-This project is not afflicted with Bionic Reading (BR®). All trademarks are the property of their respective owners.
+This project is not affiliated with Bionic Reading (BR®). All trademarks are the property of their respective owners.
 
 For more information on Bionic Reading and how it works, please see: https://bionic-reading.com/about/. Additionally, you can
 find the official Chrome extension [here](https://chrome.google.com/webstore/detail/bionic-reading/kdfkejelgkdjgfoolngegkhkiecmlflj).

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Bionic Reading Chrome Extension",
-  "description": "A chrome extension using the Bionic Reading API.",
+  "name": "Bionic Speed Reader",
+  "description": "An extension using the Bionic Reading API, to convert text to Bionic Reading®",
   "version": "0.1.0",
   "manifest_version": 3,
   "background": {

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/x-icon" href="../images/brc_logo128.png" />
-    <title>Bionic Reading Chrome Extension</title>
+    <title>Bionic Speed Reader</title>
   </head>
 
   <body>

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -3,17 +3,17 @@
   <head>
     <link rel="stylesheet" href="../css/popup.css" />
     <meta charset="utf-8" />
-    <title>Bionic Reading Popup</title>
+    <title>Bionic Speed Reader Popup</title>
   </head>
   <body>
     <div>
       <div>
         <!-- <img src="../src/images/brc_logo16.png" alt="LOGO"> -->
         <div class="row">
-          <h2>Bionic Reading</h2>
+          <h2>Bionic Speed Reader</h2>
         </div>
         <div class="row">
-          <label for="rapid-api">RapidAPI Key: </label>
+          <h4>RapidAPI Key </h2>
           <input type="text" name="rapid-api" id="apiKey" />
         </div>
         <div class="row" id="fixationOption">

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -13,13 +13,13 @@ chrome.runtime.onInstalled.addListener(() => {
  */
 chrome.contextMenus.create({
   id: "1",
-  title: "Bionic Reading convert text '%s'",
+  title: "Bionic Speed Reader convert text '%s'",
   contexts: ["selection"],
 });
 
 chrome.contextMenus.create({
   id: "2",
-  title: "Bionic Reading convert page",
+  title: "Bionic Speed Reader convert page",
   contexts: ["page"],
 });
 


### PR DESCRIPTION
# Description

the name 'Bionic Reading' is a registered trademark, the extension has been renamed to 'Bionic Speed Reader Browser Extension' instead. readme now includes a link to the official bionic reading chrome extension for users to download.

Fixes #N/A

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
