### PR TITLE
fix(options): resolve issue with preivew no longer being displayed

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -70,11 +70,12 @@
         <p>
           Disabling this feature, may result in reaching your daily API limit quicker, as multiple API calls will be
           made to convert a webpage.
-          <label>Enable</label>
-          <input id="enableFeature1E" type="checkbox" value="enable" />
-          <label>Disable</label>
-          <input id="enableFeature1D" type="checkbox" value="disable" />
         </p>
+        <hr>
+        <label>Enable</label>
+        <input id="enableFeature1E" type="radio" value="enable" />
+        <label>Disable</label>
+        <input id="enableFeature1D" type="radio" value="disable" />
       </div>
     </div>
 

--- a/src/js/convert.js
+++ b/src/js/convert.js
@@ -49,11 +49,9 @@ async function convertPageWithParagraphs() {
 
 async function checkFeaturesEnabled() {
   let convertWithUrl = await readLocalStorage("convertWithUrl");
-  if (convertWithUrl == "enable") {
-    convertPageWithWebpageUrl();
-  } else if (convertWithUrl == "disable") {
-    convertPageWithParagraphs();
-  }
+  convertWithUrl == "enable"
+    ? convertPageWithWebpageUrl()
+    : convertPageWithParagraphs();
 }
 
 checkFeaturesEnabled();

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -38,7 +38,7 @@ btnClear.addEventListener("click", () => chrome.storage.local.clear());
  */
 function previewChanges() {
   const content = document.getElementById("previewText").innerHTML;
-  requestBionic(apiKey, content, fixation, saccade);
+  requestBionic(apiKey, content, fixation, saccade, false);
 }
 
 /**


### PR DESCRIPTION
# Description

recent changes broke the preview text not being displayed on the options page, due to `isWebpageConvert` parameter not being passed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
